### PR TITLE
Add XML docs to public APIs

### DIFF
--- a/src/FastPatterns.Blazor/Core/ObservableComponentBase.cs
+++ b/src/FastPatterns.Blazor/Core/ObservableComponentBase.cs
@@ -1,11 +1,22 @@
 ﻿using Microsoft.AspNetCore.Components;
 
 namespace FastPatterns.Blazor.Core;
+/// <summary>
+/// Base component that wires up a state manager and automatically re-renders
+/// when the state changes.
+/// </summary>
+/// <typeparam name="TState">Type of the state manager used by the component.</typeparam>
 public abstract class ObservableComponentBase<TState> : ComponentBase, IDisposable
   where TState : Observer.Observer, new()
 {
+  /// <summary>
+  /// Gets or sets the injected state manager instance.
+  /// </summary>
   [Inject] protected TState State { get; set; } = default!;
 
+  /// <summary>
+  /// Registers the component with the state manager when initialized.
+  /// </summary>
   protected override void OnInitialized()
   {
     base.OnInitialized();
@@ -17,6 +28,9 @@ public abstract class ObservableComponentBase<TState> : ComponentBase, IDisposab
     InvokeAsync(StateHasChanged);
   }
 
+  /// <summary>
+  /// Removes the listener when the component is disposed.
+  /// </summary>
   public void Dispose()
   {
     State.RemoveStateChangeListeners(OnStateChanged);

--- a/src/FastPatterns.Mediator/Core/ICommand.cs
+++ b/src/FastPatterns.Mediator/Core/ICommand.cs
@@ -1,2 +1,6 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Represents a command that results in a response of type <typeparamref name="TResponse"/>.
+/// </summary>
+/// <typeparam name="TResponse">The type returned by the command handler.</typeparam>
 public interface ICommand<TResponse> : IRequest<TResponse> { }

--- a/src/FastPatterns.Mediator/Core/IMediator.cs
+++ b/src/FastPatterns.Mediator/Core/IMediator.cs
@@ -1,10 +1,29 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Dispatches requests and notifications to their appropriate handlers.
+/// </summary>
 public interface IMediator
 {
+  /// <summary>
+  /// Sends a request and returns a response.
+  /// </summary>
+  /// <param name="request">The request to send.</param>
+  /// <param name="cancellationToken">Token used to cancel the operation.</param>
+  /// <typeparam name="TResponse">Type of the response returned by the handler.</typeparam>
   Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
 
+  /// <summary>
+  /// Sends a request that does not produce a response.
+  /// </summary>
+  /// <param name="request">The request to send.</param>
+  /// <param name="cancellationToken">Token used to cancel the operation.</param>
   Task SendAsync(IRequest request, CancellationToken cancellationToken = default);
 
+  /// <summary>
+  /// Publishes a notification to all registered handlers.
+  /// </summary>
+  /// <param name="notification">The notification instance.</param>
+  /// <param name="cancellationToken">Token used to cancel the operation.</param>
   Task PublishAsync<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
       where TNotification : INotification;
 }

--- a/src/FastPatterns.Mediator/Core/INotification.cs
+++ b/src/FastPatterns.Mediator/Core/INotification.cs
@@ -1,4 +1,7 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Marker interface for notifications published via <see cref="IMediator"/>.
+/// </summary>
 public interface INotification
 {
 }

--- a/src/FastPatterns.Mediator/Core/INotificationHandler.cs
+++ b/src/FastPatterns.Mediator/Core/INotificationHandler.cs
@@ -1,6 +1,14 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Handles notifications of type <typeparamref name="TNotification"/>.
+/// </summary>
 public interface INotificationHandler<in TNotification>
     where TNotification : INotification
 {
+  /// <summary>
+  /// Processes the notification.
+  /// </summary>
+  /// <param name="notification">The notification instance.</param>
+  /// <param name="cancellationToken">Token used to cancel the operation.</param>
   Task HandleAsync(TNotification notification, CancellationToken cancellationToken);
 }

--- a/src/FastPatterns.Mediator/Core/IPipelineBehavior.cs
+++ b/src/FastPatterns.Mediator/Core/IPipelineBehavior.cs
@@ -1,11 +1,24 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Defines a step in the request processing pipeline.
+/// </summary>
 public interface IPipelineBehavior<in TRequest, TResponse>
     where TRequest : IRequest<TResponse>
 {
+  /// <summary>
+  /// Handles a request and optionally invokes the next step in the pipeline.
+  /// </summary>
+  /// <param name="request">The incoming request.</param>
+  /// <param name="next">Delegate representing the next element in the pipeline.</param>
+  /// <param name="cancellationToken">Token used to cancel the operation.</param>
+  /// <returns>The response from the next step or handler.</returns>
   Task<TResponse> HandleAsync(
       TRequest request,
       RequestHandlerDelegate<TResponse> next,
       CancellationToken cancellationToken);
 }
 
+/// <summary>
+/// Delegate representing the next request handler in the pipeline.
+/// </summary>
 public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();

--- a/src/FastPatterns.Mediator/Core/IQuery.cs
+++ b/src/FastPatterns.Mediator/Core/IQuery.cs
@@ -1,2 +1,6 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Represents a query that returns data of type <typeparamref name="TResponse"/>.
+/// </summary>
+/// <typeparam name="TResponse">The response type.</typeparam>
 public interface IQuery<TResponse> : IRequest<TResponse> { }

--- a/src/FastPatterns.Mediator/Core/IRequest.cs
+++ b/src/FastPatterns.Mediator/Core/IRequest.cs
@@ -1,7 +1,14 @@
 namespace FastPatterns.Mediator.Core;
 
+/// <summary>
+/// Represents a request that returns a response of type <typeparamref name="TResponse"/>.
+/// </summary>
+/// <typeparam name="TResponse">The type of the response.</typeparam>
 public interface IRequest<TResponse> { }
 
+/// <summary>
+/// Marker interface for requests that do not return a value.
+/// </summary>
 public interface IRequest : IRequest<Unit> { }
 
 

--- a/src/FastPatterns.Mediator/Core/IRequestHandler.cs
+++ b/src/FastPatterns.Mediator/Core/IRequestHandler.cs
@@ -1,6 +1,15 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Handles a specific type of request and returns a response.
+/// </summary>
 public interface IRequestHandler<in TRequest, TResponse>
   where TRequest : IRequest<TResponse>
 {
+  /// <summary>
+  /// Handles the request.
+  /// </summary>
+  /// <param name="request">The request instance.</param>
+  /// <param name="cancellationToken">Token used to cancel the operation.</param>
+  /// <returns>The response produced by the handler.</returns>
   public Task<TResponse> HandleAsync(TRequest request, CancellationToken cancellationToken);
 }

--- a/src/FastPatterns.Mediator/Core/Unit.cs
+++ b/src/FastPatterns.Mediator/Core/Unit.cs
@@ -1,17 +1,34 @@
 namespace FastPatterns.Mediator.Core;
+/// <summary>
+/// Represents the absence of a value. Equivalent to <c>void</c> for generic
+/// type parameters.
+/// </summary>
 public readonly struct Unit : IEquatable<Unit>
 {
+  /// <summary>
+  /// Singleton instance of <see cref="Unit"/>.
+  /// </summary>
   public static readonly Unit Value = new Unit();
 
+  /// <inheritdoc />
   public override string ToString() => "()";
 
+  /// <inheritdoc />
   public override int GetHashCode() => 0;
 
+  /// <inheritdoc />
   public override bool Equals(object? obj) => obj is Unit;
 
+  /// <inheritdoc />
   public bool Equals(Unit other) => true;
 
+  /// <summary>
+  /// Checks equality between two <see cref="Unit"/> values.
+  /// </summary>
   public static bool operator ==(Unit left, Unit right) => true;
 
+  /// <summary>
+  /// Checks inequality between two <see cref="Unit"/> values.
+  /// </summary>
   public static bool operator !=(Unit left, Unit right) => false;
 }

--- a/src/FastPatterns.Mediator/Infrastructure/Configuration/MediatorServiceCollectionExtensions.cs
+++ b/src/FastPatterns.Mediator/Infrastructure/Configuration/MediatorServiceCollectionExtensions.cs
@@ -2,8 +2,21 @@ using FastPatterns.Mediator.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FastPatterns.Mediator.Infrastructure.Configuration;
+/// <summary>
+/// Extension methods for registering mediator services with
+/// <see cref="IServiceCollection"/>.
+/// </summary>
 public static class MediatorServiceCollectionExtensions
 {
+  /// <summary>
+  /// Registers a pipeline behavior as an open generic type.
+  /// </summary>
+  /// <param name="services">The service collection to configure.</param>
+  /// <param name="behaviorType">The open generic behavior type.</param>
+  /// <returns>The updated service collection.</returns>
+  /// <exception cref="ArgumentException">
+  /// Thrown when <paramref name="behaviorType"/> is not an open generic type.
+  /// </exception>
   public static IServiceCollection AddPipeline(this IServiceCollection services, Type behaviorType)
   {
     if (!behaviorType.IsGenericTypeDefinition)
@@ -13,6 +26,12 @@ public static class MediatorServiceCollectionExtensions
     return services;
   }
 
+  /// <summary>
+  /// Adds the core mediator services and discovers handlers from the application
+  /// dependencies.
+  /// </summary>
+  /// <param name="services">The service collection to configure.</param>
+  /// <returns>The updated service collection.</returns>
   public static IServiceCollection AddMediator(this IServiceCollection services)
   {
     services.AddTransient<IMediator, Mediator>();
@@ -24,6 +43,9 @@ public static class MediatorServiceCollectionExtensions
     return services;
   }
 
+  /// <summary>
+  /// Registers all request handlers found in application dependencies.
+  /// </summary>
   private static IServiceCollection AddRequestHandlers(this IServiceCollection services)
   {
     services.Scan(scan => scan
@@ -34,6 +56,11 @@ public static class MediatorServiceCollectionExtensions
     return services;
   }
 
+  /// <summary>
+  /// Registers all notification handlers found in application dependencies.
+  /// </summary>
+  /// <param name="services">The service collection to configure.</param>
+  /// <returns>The updated service collection.</returns>
   public static IServiceCollection AddNotificationHandlers(this IServiceCollection services)
   {
     services.Scan(scan => scan

--- a/src/FastPatterns.Observer/Observer.cs
+++ b/src/FastPatterns.Observer/Observer.cs
@@ -1,15 +1,30 @@
 ﻿namespace FastPatterns.Observer;
 
+/// <summary>
+/// Provides basic functionality for managing listeners and broadcasting state
+/// changes.
+/// </summary>
 public class Observer
 {
+  /// <summary>
+  /// The registered listeners that are invoked when the state changes.
+  /// </summary>
   protected Action listeners = default!;
 
+  /// <summary>
+  /// Registers a listener to be notified when the state changes.
+  /// </summary>
+  /// <param name="listener">The callback to register.</param>
   public void AddStateChangeListeners(Action listener)
   {
     if (listener is not null)
       listeners += listener;
   }
 
+  /// <summary>
+  /// Unregisters a previously added listener.
+  /// </summary>
+  /// <param name="listener">The callback to remove.</param>
   public void RemoveStateChangeListeners(Action listener)
   {
     if (listener is not null)
@@ -18,6 +33,9 @@ public class Observer
 #pragma warning restore CS8601 // Possible null reference assignment.
   }
 
+  /// <summary>
+  /// Invokes all registered listeners.
+  /// </summary>
   public void BroadcastStateChange()
   {
     listeners?.Invoke();

--- a/src/FastPatterns.Observer/StateManager.cs
+++ b/src/FastPatterns.Observer/StateManager.cs
@@ -1,9 +1,21 @@
 ﻿namespace FastPatterns.Observer;
-public abstract class StateManager<TState> 
+/// <summary>
+/// Base class for managing and observing the state of a <see cref="ViewState" />.
+/// </summary>
+/// <typeparam name="TState">Type of the state managed by this instance.</typeparam>
+public abstract class StateManager<TState>
   : Observer where TState : ViewState
 {
+  /// <summary>
+  /// Gets the current state instance.
+  /// </summary>
   public TState? State { get; protected set; }
 
+  /// <summary>
+  /// Updates the state and broadcasts the change when it differs from the
+  /// previous value.
+  /// </summary>
+  /// <param name="newState">The new state value.</param>
   protected void SetState(TState newState)
   {
     // Only broadcast state change if the new state is different

--- a/src/FastPatterns.Observer/ViewState.cs
+++ b/src/FastPatterns.Observer/ViewState.cs
@@ -1,6 +1,16 @@
 ﻿namespace FastPatterns.Observer;
+/// <summary>
+/// Represents immutable state shared by <see cref="StateManager{TState}"/>.
+/// </summary>
 public abstract record ViewState
 {
+  /// <summary>
+  /// Gets the time when the state was last updated.
+  /// </summary>
   public DateTime LastUpdated { get; init; } = DateTime.UtcNow;
+
+  /// <summary>
+  /// Indicates whether the state is currently loading.
+  /// </summary>
   public bool IsLoading { get; init; }
 }


### PR DESCRIPTION
## Summary
- document Observer API
- document state manager types
- document Blazor base component
- document Mediator interfaces and classes
- fix leftover newline in Mediator implementation

## Testing
- `dotnet build src/FastPatterns.Mediator/FastPatterns.Mediator.csproj -v minimal`
- `dotnet build src/FastPatterns.Observer/FastPatterns.Observer.csproj -v minimal`
- `dotnet test tests/FastPatterns.Mediator.UnitTests/FastPatterns.Mediator.UnitTests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68725724d63083298c2a38d2d5f4f410