### PR TITLE
Add SimpleMapper unit tests

### DIFF
--- a/tests/FastPatterns.Extensions.UnitTests/FastPatterns.Extensions.UnitTests.csproj
+++ b/tests/FastPatterns.Extensions.UnitTests/FastPatterns.Extensions.UnitTests.csproj
@@ -16,4 +16,8 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FastPatterns.Extensions\FastPatterns.Extensions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/FastPatterns.Extensions.UnitTests/Mapping/SimpleMapperTests.cs
+++ b/tests/FastPatterns.Extensions.UnitTests/Mapping/SimpleMapperTests.cs
@@ -1,10 +1,57 @@
-﻿namespace FastPatterns.Extensions.UnitTests.Mapping;
+using FastPatterns.Extensions.Mapping;
+
+namespace FastPatterns.Extensions.UnitTests.Mapping;
 
 [TestClass]
 public sealed class SimpleMapperTests
 {
-  [TestMethod]
-  public void TestMethod1()
-  {
-  }
+    private class Source
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public int Age { get; set; }
+    }
+
+    private class Target
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public long Age { get; set; } // different type should not be mapped
+        public int ReadOnlyProp { get; private set; }
+    }
+
+    [TestMethod]
+    public void Map_NullSource_Returns_Default_Target()
+    {
+        var result = SimpleMapper<Source, Target>.Map(null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Id);
+        Assert.IsNull(result.Name);
+        Assert.AreEqual(0L, result.Age);
+    }
+
+    [TestMethod]
+    public void Map_Maps_Matching_Properties()
+    {
+        var src = new Source { Id = 3, Name = "Alice", Age = 30 };
+
+        var result = SimpleMapper<Source, Target>.Map(src);
+
+        Assert.AreEqual(src.Id, result.Id);
+        Assert.AreEqual(src.Name, result.Name);
+    }
+
+    [TestMethod]
+    public void Map_Ignores_NonMatching_And_ReadOnly_Properties()
+    {
+        var src = new Source { Id = 5, Name = "Bob", Age = 42 };
+
+        var result = SimpleMapper<Source, Target>.Map(src);
+
+        // Age type differs so should remain default
+        Assert.AreEqual(0L, result.Age);
+        // ReadOnlyProp cannot be set
+        Assert.AreEqual(0, result.ReadOnlyProp);
+    }
 }


### PR DESCRIPTION
## Summary
- add project reference from Extensions tests project to Extensions project
- implement SimpleMapper unit tests covering Map behavior

## Testing
- `dotnet test tests/FastPatterns.Extensions.UnitTests/FastPatterns.Extensions.UnitTests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687a29b1063c8329b4ec8768e1766909