### PR TITLE
Update validation example and docs

### DIFF
--- a/FastPatterns.Validation/CreateUserHandler.cs
+++ b/FastPatterns.Validation/CreateUserHandler.cs
@@ -7,8 +7,7 @@ public record CreateUserCommand : ICommand<bool>
 {
   public string? Name { get; set; }
   public string? Username { get; set; }
-  public string? Password { get; set; }
-  public string? PasswordMatch { get; set; }
+  public string? Email { get; set; }
 }
 
 public class CreateUserCommandValidator : IValidator<CreateUserCommand>
@@ -25,13 +24,13 @@ public class CreateUserCommandValidator : IValidator<CreateUserCommand>
     {
       errors.Add(new ValidationError(nameof(request.Username), "Username is required."));
     }
-    if (string.IsNullOrWhiteSpace(request.Password))
+    if (string.IsNullOrWhiteSpace(request.Email))
     {
-      errors.Add(new ValidationError(nameof(request.Password), "Password is required."));
+      errors.Add(new ValidationError(nameof(request.Email), "Email is required."));
     }
-    if (request.Password != request.PasswordMatch)
+    else if (!request.Email.Contains('@'))
     {
-      errors.Add(new ValidationError(nameof(request.PasswordMatch), "Passwords must match."));
+      errors.Add(new ValidationError(nameof(request.Email), "Email must be valid."));
     }
 
     return Task.FromResult<IEnumerable<ValidationError>>(errors);

--- a/FastPatterns.Validation/Program.cs
+++ b/FastPatterns.Validation/Program.cs
@@ -18,9 +18,8 @@ try
   var result = await mediator.SendAsync(new CreateUserCommand()
   {
     Name = "John Doe",
-    Password = "johnDoe1",
-    PasswordMatch = "jonDoe1",
-    Username = "doe87"
+    Username = "doe87",
+    Email = "john@doe.com"
   });
 
   Console.WriteLine($"User creation result: {result}");

--- a/README.md
+++ b/README.md
@@ -92,7 +92,26 @@ The `FastPatterns.Mediator` project provides a simple mediator with request/resp
 - Request handlers implement `IRequestHandler<TRequest, TResponse>` while notifications use `INotificationHandler<TNotification>`.
 - `IPipelineBehavior` allows cross-cutting code to run before and after a request handler.
 - Extension methods register the mediator and all handlers with `IServiceCollection`.
+- `AddValidationBehavior` registers the built-in validation pipeline and discovers all `IValidator<T>` implementations.
 - See `samples/FastPatterns.Mediator.WebApiSample` for a minimal API example.
+
+### Validation Pipeline Example
+
+```csharp
+var services = new ServiceCollection();
+services.AddMediator()
+        .AddValidationBehavior();
+
+var mediator = services.BuildServiceProvider()
+                       .GetRequiredService<IMediator>();
+
+await mediator.SendAsync(new CreateUserCommand
+{
+    Name = "John Doe",
+    Username = "doe87",
+    Email = "john@doe.com"
+});
+```
 
 ## Observer
 `FastPatterns.Observer` implements a basic observable state system.


### PR DESCRIPTION
## Summary
- remove password fields from validation example
- add email property and validator checks
- mention validation pipeline in the README and show usage

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687e27b5acf88329aab86116b0077809